### PR TITLE
Ajustes de compilação relacionado a compatibilidade;

### DIFF
--- a/src/BCrypt.Types.pas
+++ b/src/BCrypt.Types.pas
@@ -17,7 +17,9 @@ type
   end;
 
   EBCrypt = class(Exception);
+  {$IFDEF POSIX}
   UTF8String = type AnsiString(CP_UTF8);
+  {$ENDIF POSIX}  
 
 implementation
 


### PR DESCRIPTION
Na classe System.SysUtils a constante CP_UTF8 se utiliza da Conditional compilation POSIX;

* Referencias:
[http://docwiki.embarcadero.com/RADStudio/Rio/en/Conditional_compilation_(Delphi)]