### PR TITLE
Estava gerando um Vazamento de memoria

### DIFF
--- a/src/BCrypt.Core.pas
+++ b/src/BCrypt.Core.pas
@@ -285,7 +285,7 @@ var
   I: Longint;
 begin
   SetLength(LRandomTemp, 17);
-  SetLength(LByteArray, 16);
+  SetLength(LByteArray, 17);
   Randomize;
   LRandomTemp := MTRandomBytes(BCRYPT_SALT_LEN);
   I := 0;


### PR DESCRIPTION
Após o while ao fazer  SetLength(LByteArray, 16);  FastMM reportava um memory leak sentando a variável no começo para 17  corrige o problema.