### PR TITLE
Added suppot for 2b Bcrypt Hash type and increased Cost to 12

### DIFF
--- a/src/BCrypt.Consts.pas
+++ b/src/BCrypt.Consts.pas
@@ -7,7 +7,7 @@ uses {$IFDEF FPC}Types{$ELSE}System.Types{$ENDIF};
 const
   BCRYPT_SALT_LEN = 16;
   BLOWFISH_NUM_ROUNDS = 16;
-  BCRYPT_DEFAULT_COST = 10;
+  BCRYPT_DEFAULT_COST = 12;
 
   PBoxOrg: array [0 .. 17] of DWORD = (
     $243f6a88, $85a308d3, $13198a2e, $03707344, $a4093822, $299f31d0, $082efa98,

--- a/src/BCrypt.Core.pas
+++ b/src/BCrypt.Core.pas
@@ -219,8 +219,10 @@ begin
   case AHashType of
     THashType.BSD:
       LPrefix := '2a';
-    THashType.PHP, THashType.Default:
+    THashType.PHP :
       LPrefix := '2y';
+    THashType.Default:
+      LPrefix := '2b';
   end;
   LSalt := BsdBase64Encode(ASalt, Length(ASalt));
   LHash := BsdBase64Encode(AHash, Length(MagicText) * 4 - 1);
@@ -338,11 +340,13 @@ end;
 
 function TBCryptImpl.ResolveHashType(const AHashType: string): THashType;
 begin
-  case AnsiIndexStr(AHashType, ['$2y$', '$2a$']) of
+  case AnsiIndexStr(AHashType, ['$2y$', '$2a$','$2b$']) of
     0:
       Result := THashType.PHP;
     1:
       Result := THashType.BSD;
+    2:
+      Result := THashType.Default; // added as being current default
     else
       Result := THashType.Unknown;
   end;

--- a/src/BCrypt.pas
+++ b/src/BCrypt.pas
@@ -22,7 +22,7 @@ uses BCrypt.Consts, BCrypt.Core;
 
 class function TBCrypt.GenerateHash(const APassword: string): string;
 begin
-  Result := TBCryptImpl.New.GenerateHash(UTF8String(APassword), THashType.BSD, BCRYPT_DEFAULT_COST);
+  Result := TBCryptImpl.New.GenerateHash(UTF8String(APassword), THashType.Default, BCRYPT_DEFAULT_COST);
 end;
 
 class function TBCrypt.GenerateHash(const APassword: string; ACost: Byte): string;


### PR DESCRIPTION
This modifications let the library successfully create and validate BCrypt hashes with the '$2b$' algorithm (e.g. generated with Pythons bcrypt library)
Based on [this information](https://passlib.readthedocs.io/en/stable/lib/passlib.hash.bcrypt.html) the $2b$ algorithm is the same as $2y$ but the current default. Therefore no major code changes needed to be done.

In addition, the BCRYPT_DEFAULT_COST was increased from 10 -> 12 (also the current recommended default value)

I've tested the following:
- Validate a BCrypt hash generated with Python BCrypt library
- Generate a 2b BCrypt hash
- Validate self generated hash
- Generate a 2b BCrypt hash and validate against external libraries

Feel free to contact me if you have any additional questions


